### PR TITLE
Refactor useFetchData hook to a function instead of custom hook.

### DIFF
--- a/src/ducks/ui.js
+++ b/src/ducks/ui.js
@@ -1,7 +1,6 @@
 const TOGGLE_THEME = 'UI/TOGGLE_THEME';
 const UPDATE_CURRENT_PAGE = 'UI/UPDATE_CURRENT_PAGE';
 const UPDATE_CURRENT_TAB = 'UI/UPDATE_CURRENT_TAB';
-const TOGGLE_DASHBOARD_IS_LOADING = 'UI/TOGGLE_DASHBOARD_IS_LOADING';
 const TOGGLE_TRANSACTION_SETTINGS_POPUP = 'UI/TOGGLE_TRANSACTION_SETTINGS_POPUP';
 
 // Reducer
@@ -19,9 +18,7 @@ export default (state, action) => {
 			const { tab, params } = action.payload;
 			return { ...state, currentTab: tab, tabParams: params };
 		}
-		case TOGGLE_DASHBOARD_IS_LOADING: {
-			return { ...state, dashboardIsLoading: action.payload };
-		}
+
 		case TOGGLE_TRANSACTION_SETTINGS_POPUP: {
 			return { ...state, transactionSettingsPopupIsVisible: action.payload };
 		}
@@ -49,13 +46,6 @@ export const updateCurrentTab = (tab, dispatch, params = null) => {
 	return dispatch({
 		type: UPDATE_CURRENT_TAB,
 		payload: { tab, params },
-	});
-};
-
-export const toggleDashboardIsLoading = (isLoading, dispatch) => {
-	return dispatch({
-		type: TOGGLE_DASHBOARD_IS_LOADING,
-		payload: isLoading,
 	});
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ const initialState = {
 		themeIsDark: localStorage.getItem('dark') === 'true' || false,
 		currentPage: 'landing',
 		currentTab: 'home',
-		dashboardIsLoading: false,
 		transactionSettingsPopupIsVisible: false,
 	},
 	wallet: {

--- a/src/screens/Dashboard/fetchData.js
+++ b/src/screens/Dashboard/fetchData.js
@@ -1,11 +1,7 @@
-import { useState, useEffect, useContext } from 'react';
 import { addSeconds } from 'date-fns';
 import snxJSConnector from '../../helpers/snxJSConnector';
 
-import { Store } from '../../store';
-
 import { bytesFormatter } from '../../helpers/formatters';
-import { toggleDashboardIsLoading } from '../../ducks/ui';
 
 const bigNumberFormatter = value => Number(snxJSConnector.utils.formatEther(value));
 
@@ -126,36 +122,22 @@ const getSynths = async walletAddress => {
 	}
 };
 
-export const useFetchData = (walletAddress, successQueue, forceRefresh) => {
-	const [data, setData] = useState({});
-	const { dispatch } = useContext(Store);
-	useEffect(() => {
-		try {
-			toggleDashboardIsLoading(true, dispatch);
-			const fetchData = async () => {
-				const [balances, prices, rewardData, debtData, escrowData, synthData] = await Promise.all([
-					getBalances(walletAddress),
-					getPrices(),
-					getRewards(walletAddress),
-					getDebt(walletAddress),
-					getEscrow(walletAddress),
-					getSynths(walletAddress),
-				]);
-				setData({
-					balances,
-					prices,
-					rewardData,
-					debtData,
-					escrowData,
-					synthData,
-				});
-				toggleDashboardIsLoading(false, dispatch);
-			};
-			fetchData();
-		} catch (e) {
-			console.log(e);
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [walletAddress, successQueue.length, forceRefresh]);
-	return data;
+export const fetchData = async walletAddress => {
+	const [balances, prices, rewardData, debtData, escrowData, synthData] = await Promise.all([
+		getBalances(walletAddress),
+		getPrices(),
+		getRewards(walletAddress),
+		getDebt(walletAddress),
+		getEscrow(walletAddress),
+		getSynths(walletAddress),
+	]).catch(e => console.log(e));
+
+	return {
+		balances,
+		prices,
+		rewardData,
+		debtData,
+		escrowData,
+		synthData,
+	};
 };


### PR DESCRIPTION
I was just looking through the codebase and saw a hack comment, so I thought a small refactoring could be in place. 

Having it as a function makes it easy to call it on click, we can also easily call it in an interval if we'd like. 
I also moved the dashboardIsLoading flag from context to local state since it's only used in the dashboard.

Another future loading improvement could be to not use the Skeleton Loader if we have data, but some small indicator showing that it's updating, then we could easily refresh the dashboard on an interval.
