### PR TITLE
derivation path logic fixes

### DIFF
--- a/src/components/SimpleSelect/SimpleSelect.js
+++ b/src/components/SimpleSelect/SimpleSelect.js
@@ -17,6 +17,13 @@ export default function SimpleSelect(props) {
 					color: colorStyles.heading,
 					boxShadow: 'none',
 					border: 'none',
+					'&:hover': {
+						opacity: 0.2,
+					},
+				}),
+				container: provided => ({
+					...provided,
+					opacity: props.isDisabled ? 0.4 : 1,
 				}),
 				control: provided => ({
 					...provided,

--- a/src/components/SimpleSelect/SimpleSelect.js
+++ b/src/components/SimpleSelect/SimpleSelect.js
@@ -12,18 +12,15 @@ export default function SimpleSelect(props) {
 	return (
 		<Select
 			styles={{
+				container: provided => ({
+					...provided,
+					opacity: props.isDisabled ? 0.4 : 1,
+				}),
 				singleValue: provided => ({
 					...provided,
 					color: colorStyles.heading,
 					boxShadow: 'none',
 					border: 'none',
-					'&:hover': {
-						opacity: 0.2,
-					},
-				}),
-				container: provided => ({
-					...provided,
-					opacity: props.isDisabled ? 0.4 : 1,
 				}),
 				control: provided => ({
 					...provided,

--- a/src/ducks/wallet.js
+++ b/src/ducks/wallet.js
@@ -12,7 +12,12 @@ export default (state, action) => {
 			return { ...state, walletPaginatorIndex: action.payload };
 		}
 		case SET_DERIVATION_PATH: {
-			return { ...state, derivationPath: action.payload };
+			return {
+				...state,
+				derivationPath: action.payload,
+				availableWallets: [],
+				walletPaginatorIndex: 0,
+			};
 		}
 		default:
 			return state;

--- a/src/helpers/snxJSConnector.js
+++ b/src/helpers/snxJSConnector.js
@@ -1,8 +1,6 @@
 import { SynthetixJs } from 'synthetix-js';
 import { getEthereumNetwork, INFURA_JSON_RPC_URLS } from './networkHelper';
 
-const DEFAULT_LEDGER_DERIVATION_PATH = "44'/60'/0'/";
-
 let snxJSConnector = {
 	initialized: false,
 	signers: SynthetixJs.signers,
@@ -88,11 +86,11 @@ const connectToHardwareWallet = (networkId, networkName, walletType) => {
 		unlocked: true,
 		networkId,
 		networkName: networkName.toLowerCase(),
-		derivationPath: walletType === 'Ledger' ? DEFAULT_LEDGER_DERIVATION_PATH : null,
 	};
 };
 
 const getSignerConfig = ({ type, networkId, derivationPath }) => {
+	const DEFAULT_LEDGER_DERIVATION_PATH = "44'/60'/0'/";
 	if (type === 'Ledger') {
 		return { derivationPath: derivationPath || DEFAULT_LEDGER_DERIVATION_PATH };
 	}

--- a/src/helpers/snxJSConnector.js
+++ b/src/helpers/snxJSConnector.js
@@ -1,6 +1,8 @@
 import { SynthetixJs } from 'synthetix-js';
 import { getEthereumNetwork, INFURA_JSON_RPC_URLS } from './networkHelper';
 
+const DEFAULT_LEDGER_DERIVATION_PATH = "44'/60'/0'/";
+
 let snxJSConnector = {
 	initialized: false,
 	signers: SynthetixJs.signers,
@@ -86,12 +88,12 @@ const connectToHardwareWallet = (networkId, networkName, walletType) => {
 		unlocked: true,
 		networkId,
 		networkName: networkName.toLowerCase(),
+		derivationPath: DEFAULT_LEDGER_DERIVATION_PATH,
 	};
 };
 
 const getSignerConfig = ({ type, networkId, derivationPath }) => {
 	if (type === 'Ledger') {
-		const DEFAULT_LEDGER_DERIVATION_PATH = "44'/60'/0'/";
 		return { derivationPath: derivationPath || DEFAULT_LEDGER_DERIVATION_PATH };
 	}
 	if (type === 'Coinbase') {

--- a/src/helpers/snxJSConnector.js
+++ b/src/helpers/snxJSConnector.js
@@ -90,8 +90,8 @@ const connectToHardwareWallet = (networkId, networkName, walletType) => {
 };
 
 const getSignerConfig = ({ type, networkId, derivationPath }) => {
-	const DEFAULT_LEDGER_DERIVATION_PATH = "44'/60'/0'/";
 	if (type === 'Ledger') {
+		const DEFAULT_LEDGER_DERIVATION_PATH = "44'/60'/0'/";
 		return { derivationPath: derivationPath || DEFAULT_LEDGER_DERIVATION_PATH };
 	}
 	if (type === 'Coinbase') {

--- a/src/helpers/snxJSConnector.js
+++ b/src/helpers/snxJSConnector.js
@@ -88,7 +88,7 @@ const connectToHardwareWallet = (networkId, networkName, walletType) => {
 		unlocked: true,
 		networkId,
 		networkName: networkName.toLowerCase(),
-		derivationPath: DEFAULT_LEDGER_DERIVATION_PATH,
+		derivationPath: walletType === 'Ledger' ? DEFAULT_LEDGER_DERIVATION_PATH : null,
 	};
 };
 

--- a/src/pages/WalletSelection/WalletSelection.js
+++ b/src/pages/WalletSelection/WalletSelection.js
@@ -35,7 +35,7 @@ import { ButtonPrimaryMedium } from '../../components/Button';
 const WALLET_PAGE_SIZE = 5;
 const LEDGER_DERIVATION_PATHS = [
 	{ value: "44'/60'/0'/", label: "Ethereum - m/44'/60'/0'" },
-	{ value: "44'/60'/0'/0", label: "Ethereum - Ledger Live - m/44'/60'" },
+	{ value: "44'/60'/0'/0/0", label: "Ethereum - Ledger Live - m/44'/60'/0'/0" },
 ];
 const useGetWallets = (paginatorIndex, derivationPath) => {
 	const {
@@ -46,7 +46,6 @@ const useGetWallets = (paginatorIndex, derivationPath) => {
 	} = useContext(Store);
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState(null);
-
 	useEffect(() => {
 		const walletIndex = paginatorIndex * WALLET_PAGE_SIZE;
 		if (availableWallets[walletIndex]) return;
@@ -161,6 +160,9 @@ const WalletConnection = ({ t }) => {
 	const { isLoading, error } = useGetWallets(walletPaginatorIndex, derivationPath);
 	const isHardwareWallet = ['Ledger', 'Trezor'].includes(walletType);
 	const isLedger = walletType === 'Ledger';
+	const selectedDerivationPath = derivationPath
+		? LEDGER_DERIVATION_PATHS.find(path => path.value === derivationPath)
+		: LEDGER_DERIVATION_PATHS[0];
 	return (
 		<OnBoardingPageContainer>
 			<Content>
@@ -177,12 +179,13 @@ const WalletConnection = ({ t }) => {
 						{isLedger && (
 							<SelectWrapper>
 								<SimpleSelect
+									isDisabled={isLoading}
 									searchable={false}
 									options={LEDGER_DERIVATION_PATHS}
-									value={derivationPath || LEDGER_DERIVATION_PATHS[0]}
+									value={selectedDerivationPath}
 									onChange={option => {
 										setSigner({ type: 'Ledger', networkId, derivationPath: option.value });
-										setDerivationPath(option, dispatch);
+										setDerivationPath(option.value, dispatch);
 									}}
 								></SimpleSelect>
 							</SelectWrapper>


### PR DESCRIPTION
- Live Derivation Path updated. The one I gave you was wrong.
- Updated `setDerivationPath` action so it can clear some of the data in the store. If `availableWallets` is not empty then the useEffect doesn't trigger.
- Locking the input while data is loading.