### PR TITLE
52 susd to usd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,3 +26,5 @@ jobs:
       - run: npm run lint
 
       - run: npm run lint:css
+
+      - run: npm run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,59 @@
-version: 2
+env_defaults: &env_defaults
+  working_directory: ~
+  docker:
+    - image: circleci/node:10.16
+
+version: 2.1
 jobs:
   build:
-    docker:
-      - image: 'circleci/node:10.16.3'
-
-    working_directory: ~
-
+    <<: *env_defaults
     steps:
       - checkout
 
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
+            - v1.0-dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v1.0-dependencies-
 
       - run: npm install
 
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v1.0-dependencies-{{ checksum "package.json" }}
 
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+
+  lint:
+    <<: *env_defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
       - run: npm run lint
 
-      - run: npm run lint:css
+  test:
+    <<: *env_defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: npm test
 
-      - run: npm run test
+workflows:
+  version: 2
+
+  build-lint-test:
+    jobs:
+      - build
+      - lint:
+          requires:
+            - build
+      - test:
+          requires:
+            - build

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
 		browser: true,
 		es6: true,
 		node: true,
+		jest: true,
 	},
 	parser: 'babel-eslint',
 	extends: 'eslint:recommended',

--- a/src/screens/Dashboard/fetchData.test.js
+++ b/src/screens/Dashboard/fetchData.test.js
@@ -1,0 +1,14 @@
+import { getSusdInUsd } from './fetchData';
+
+describe('getSusdInUsd', () => {
+	test('converts correctly', () => {
+		const synthRates = {
+			susd: 1,
+			eth: 150.89559276124712,
+			seth: 150.89559276124712,
+		};
+		const sethToEthRate = 0.9838261979298352;
+		const result = getSusdInUsd(synthRates, sethToEthRate);
+		expect(result).toBe(0.9838261979298352);
+	});
+});


### PR DESCRIPTION
A bit tricky but think I got it right.


The snxJS lib seems to return the same rate for sETH and ETH?

Since Synths and Debts uses the sUSD rated they no show different values, I guess this is what we wanted? 

![image](https://user-images.githubusercontent.com/5688912/69489506-27616400-0ecd-11ea-99df-fda72f4f82d1.png)


#52 