### PR TITLE
Remove eth when calculating sUSD

### DIFF
--- a/src/screens/Dashboard/fetchData.js
+++ b/src/screens/Dashboard/fetchData.js
@@ -27,7 +27,7 @@ const convertFromSynth = (fromSynthRate, toSynthRate) => {
 export const getSusdInUsd = (synthRates, sethToEthRate) => {
 	const sEth = convertFromSynth(synthRates.susd, synthRates.seth);
 	const eth = sEth * sethToEthRate;
-	return eth * synthRates.eth;
+	return eth * synthRates.seth;
 };
 const getSETHtoETH = async () => {
 	const exchangeAddress = '0xe9cf7887b93150d4f2da7dfc6d502b216438f244';
@@ -39,9 +39,8 @@ const getSETHtoETH = async () => {
 
 const getPrices = async () => {
 	try {
-		// sETH seems to be the same as ETH??
 		const synthsP = snxJSConnector.snxJS.ExchangeRates.ratesForCurrencies(
-			['SNX', 'sUSD', 'ETH', 'sETH'].map(bytesFormatter)
+			['SNX', 'sUSD', 'sETH'].map(bytesFormatter)
 		);
 		const sethToEthRateP = getSETHtoETH();
 		const [synths, sethToEthRate] = await Promise.all([synthsP, sethToEthRateP]);

--- a/src/screens/Dashboard/fetchData.test.js
+++ b/src/screens/Dashboard/fetchData.test.js
@@ -4,7 +4,6 @@ describe('getSusdInUsd', () => {
 	test('converts correctly', () => {
 		const synthRates = {
 			susd: 1,
-			eth: 150.89559276124712,
 			seth: 150.89559276124712,
 		};
 		const sethToEthRate = 0.9838261979298352;


### PR DESCRIPTION
I removed ETH from the sUSD conversion.

Eth is used in a lot of places, like when we calculate gas price etc. 
I could try and refactor that, but it might be quicker for you @clementbalestrat since you wrote the code?

Just let me know if you think it's worth me spending time on that.

I also has some questions regarding the UI that says it displaying ETH and not sETH. (#107 )