### PR TITLE
Make claim action screen more mobile friendly

### DIFF
--- a/src/screens/MintrActions/Claim/Action.js
+++ b/src/screens/MintrActions/Claim/Action.js
@@ -128,7 +128,7 @@ const Action = ({
 					</Details>
 				</Middle>
 				<Bottom>
-					<TransactionPriceIndicator style={{ margin: '10px 0' }} />
+					<TransactionPriceIndicator style={{ margin: '0' }} />
 					<ButtonPrimary
 						disabled={!feesAreClaimable || isFetchingGasLimit || gasEstimateError}
 						onClick={onClaim}
@@ -144,7 +144,7 @@ const Action = ({
 		</SlidePage>
 	);
 };
-
+const WrapTableBreakpoint = 1310;
 const Container = styled.div`
 	width: 100%;
 	height: 850px;
@@ -171,6 +171,9 @@ const Middle = styled.div`
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
+	@media (max-width: ${WrapTableBreakpoint}px) {
+		flex-direction: column;
+	}
 `;
 
 const Bottom = styled.div`
@@ -201,6 +204,9 @@ const Schedule = styled.div`
 	margin: 8px 16px 8px 0px;
 	padding: 24px 16px 0 16px;
 	text-align: left;
+	@media (max-width: ${WrapTableBreakpoint}px) {
+		width: 100%;
+	}
 `;
 
 const Status = styled.div`
@@ -220,6 +226,16 @@ const Details = styled.div`
 	display: flex;
 	flex-direction: column;
 	width: 40%;
+	@media (max-width: ${WrapTableBreakpoint}px) {
+		flex-direction: row;
+		width: 100%;
+		justify-content: space-between;
+		> div {
+			width: calc(50% - 8px);
+			padding-top: 16px;
+			padding-bottom: 16px;
+		}
+	}
 `;
 
 const Box = styled.div`
@@ -248,7 +264,7 @@ const Highlighted = styled.span`
 `;
 
 const Note = styled.div`
-	margin-top: 24px;
+	margin-top: 16px;
 	max-width: 420px;
 `;
 


### PR DESCRIPTION
It was a bit hard to make everything fit on the smaller screen, so I did some "devsigning".
Made the intro text smaller etc. If you want to improve it somehow just let me know, designing is my strongest skill... But at least everything fits now. (It is overflowing in prod right now too)

![Screen Shot 2019-11-28 at 8 23 31 am](https://user-images.githubusercontent.com/5688912/69760357-756db480-11b8-11ea-9a44-bb699ad0e42c.png)
![Screen Shot 2019-11-28 at 8 23 41 am](https://user-images.githubusercontent.com/5688912/69760360-77d00e80-11b8-11ea-8465-6406b5de303c.png)
![Screen Shot 2019-11-28 at 8 23 56 am](https://user-images.githubusercontent.com/5688912/69760362-7a326880-11b8-11ea-9c06-7c162a4c5ac2.png)
