### PR TITLE
Use language from localstorage before navigator.

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -10,7 +10,7 @@ i18n
 	.init({
 		fallbackLng: 'en',
 		detection: {
-			order: ['navigator'],
+			order: ['localStorage', 'navigator'],
 		},
 		react: {
 			useSuspense: true,


### PR DESCRIPTION
This means that if the user has picked another language we will default to that.