### PR TITLE
Dapp handlers

### DIFF
--- a/src/screens/Dashboard/fetchData.js
+++ b/src/screens/Dashboard/fetchData.js
@@ -1,11 +1,10 @@
 import { addSeconds } from 'date-fns';
 import snxJSConnector from '../../helpers/snxJSConnector';
-
 import { bytesFormatter } from '../../helpers/formatters';
 
 const bigNumberFormatter = value => Number(snxJSConnector.utils.formatEther(value));
 
-const getBalances = async walletAddress => {
+export const getBalances = async walletAddress => {
 	try {
 		const result = await Promise.all([
 			snxJSConnector.snxJS.Synthetix.collateral(walletAddress),


### PR DESCRIPTION
I've added event listener for issuing and burning of sUSD and if the event is on the current account we update the balance. I debounced the listener since the event seems to be triggered more than once when you mint.

I think we should try to add all events to this PR before merging. Eg. 
Transfers, Exchange Rates, Deposits/ Withdrawals.

I also think we can use the debounce tactic to minimize requests, the debounce could be quite high for some things if needed.

The events should probably be documented on the [SynthetixJS docs page](https://synthetixjs.synthetix.io/). I don't think I'm the best person to do that since I'm very unfamiliar with the .sol contract code. 
I'm happy to finish this PR when the events have been documented though.  Unless you prefer to do it in which case you can just continue working on this branch.





#58