### PR TITLE
Compare string primitives of lodash inverted map

### DIFF
--- a/src/helpers/networkHelper.js
+++ b/src/helpers/networkHelper.js
@@ -115,4 +115,4 @@ export function onMetamaskNetworkChange(cb) {
 export const addBufferToGasLimit = gasLimit =>
 	Math.round(Number(gasLimit) * (1 + GAS_LIMIT_BUFFER_PERCENTAGE));
 
-export const isMainNet = networkId => networkId === SUPPORTED_NETWORKS_MAP.MAINNET;
+export const isMainNet = networkId => networkId.toString() === SUPPORTED_NETWORKS_MAP.MAINNET;


### PR DESCRIPTION
Depot has link through https://mainnet.etherscan.io/ because strict equality is comparing a number to a string