### PR TITLE
refactor: <GlobalEventsGate/> to poll for infura events on focus/blur…

### DIFF
--- a/src/gates/GlobalEventsGate.tsx
+++ b/src/gates/GlobalEventsGate.tsx
@@ -44,39 +44,39 @@ const GlobalEventsGate: FC<PropsFromRedux> = ({
 }) => {
 	const isFocused = useWindowFocus();
 	useEffect(() => {
-		if (!currentWallet) return;
+		console.log('isFocused first', isFocused);
 		const {
 			//@ts-ignore
 			snxJS: { sUSD, FeePool, Synthetix, RewardEscrow, SynthetixEscrow },
 		} = snxJSConnector;
 
-		sUSD.contract.on(ISSUANCE_EVENTS.ISSUED, (account: string) => {
-			if (account === currentWallet && isFocused) {
-				fetchDebtStatusRequest();
-				fetchBalancesRequest();
-			}
-		});
-		sUSD.contract.on(ISSUANCE_EVENTS.BURNED, (account: string) => {
-			if (account === currentWallet && isFocused) {
-				fetchDebtStatusRequest();
-				fetchBalancesRequest();
-			}
-		});
-		FeePool.contract.on(FEEPOOL_EVENTS.CLAIMED, (account: string) => {
-			if (account === currentWallet && isFocused) {
-				fetchBalancesRequest();
-				fetchDebtStatusRequest();
-				fetchEscrowRequest();
-			}
-		});
-		Synthetix.contract.on(EXCHANGE_EVENTS.SYNTH_EXCHANGE, (address: string) => {
-			if (address === currentWallet && isFocused) {
-				fetchBalancesRequest();
-				fetchDebtStatusRequest();
-			}
-		});
-
-		return () => {
+		if (isFocused && currentWallet) {
+			sUSD.contract.on(ISSUANCE_EVENTS.ISSUED, (account: string) => {
+				if (account === currentWallet) {
+					fetchDebtStatusRequest();
+					fetchBalancesRequest();
+				}
+			});
+			sUSD.contract.on(ISSUANCE_EVENTS.BURNED, (account: string) => {
+				if (account === currentWallet) {
+					fetchDebtStatusRequest();
+					fetchBalancesRequest();
+				}
+			});
+			FeePool.contract.on(FEEPOOL_EVENTS.CLAIMED, (account: string) => {
+				if (account === currentWallet) {
+					fetchBalancesRequest();
+					fetchDebtStatusRequest();
+					fetchEscrowRequest();
+				}
+			});
+			Synthetix.contract.on(EXCHANGE_EVENTS.SYNTH_EXCHANGE, (address: string) => {
+				if (address === currentWallet) {
+					fetchBalancesRequest();
+					fetchDebtStatusRequest();
+				}
+			});
+		} else {
 			Object.values(ISSUANCE_EVENTS).forEach(event => sUSD.contract.removeAllListeners(event));
 			Object.values(FEEPOOL_EVENTS).forEach(event => FeePool.contract.removeAllListeners(event));
 			Object.values(EXCHANGE_EVENTS).forEach(event => Synthetix.contract.removeAllListeners(event));
@@ -88,31 +88,33 @@ const GlobalEventsGate: FC<PropsFromRedux> = ({
 			Object.values(REWARD_ESCROW_EVENTS).forEach(event =>
 				RewardEscrow.contract.removeAllListeners(event)
 			);
-		};
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [currentWallet, isFocused]);
 
 	useEffect(() => {
+		console.log('isFocused second', isFocused);
 		const {
 			//@ts-ignore
 			snxJS: { SystemStatus, ExchangeRates },
 		} = snxJSConnector;
-		SystemStatus.contract.on(SYSTEM_STATUS_EVENTS.SYSTEM_SUSPENDED, (reason: number) => {
-			setSystemUpgrading({ reason: true });
-		});
-		SystemStatus.contract.on(SYSTEM_STATUS_EVENTS.SYSTEM_RESUMED, () => {
-			setSystemUpgrading({ reason: false });
-		});
-		return () => {
+		if (isFocused) {
+			SystemStatus.contract.on(SYSTEM_STATUS_EVENTS.SYSTEM_SUSPENDED, (reason: number) => {
+				setSystemUpgrading({ reason: true });
+			});
+			SystemStatus.contract.on(SYSTEM_STATUS_EVENTS.SYSTEM_RESUMED, () => {
+				setSystemUpgrading({ reason: false });
+			});
+		} else {
 			Object.values(SYSTEM_STATUS_EVENTS).forEach(event =>
 				SystemStatus.contract.removeAllListeners(event)
 			);
 			Object.values(EXCHANGE_RATES_EVENTS).forEach(event =>
 				ExchangeRates.contract.removeAllListeners(event)
 			);
-		};
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [isFocused]);
 	return null;
 };
 

--- a/src/hooks/useWindowFocus.ts
+++ b/src/hooks/useWindowFocus.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 const useWindowFocus = () => {
 	const [focused, setFocused] = useState(false);
+	console.log('useWindowFocus focused?', focused);
 
 	useEffect(() => {
 		// First render

--- a/src/hooks/useWindowFocus.ts
+++ b/src/hooks/useWindowFocus.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+const useWindowFocus = () => {
+	const [focused, setFocused] = useState(false);
+
+	useEffect(() => {
+		// First render
+		setFocused(document.hasFocus());
+
+		const onFocus = () => setFocused(true);
+		const onBlur = () => setFocused(false);
+
+		window.addEventListener('focus', onFocus);
+		window.addEventListener('blur', onBlur);
+
+		return () => {
+			window.removeEventListener('focus', onFocus);
+			window.removeEventListener('blur', onBlur);
+		};
+	}, []);
+
+	return focused;
+};
+
+export default useWindowFocus;


### PR DESCRIPTION
These hooks are event based so after the fix I shouldn't see requests even when the window is in focus right as long as there wasnt a qualifying event?