### PR TITLE
Hide banner if SNX balance <= 5000

### DIFF
--- a/src/components/Banner/L2Banner.tsx
+++ b/src/components/Banner/L2Banner.tsx
@@ -8,18 +8,22 @@ import { fontFamilies } from 'styles/themes';
 import { RootState } from 'ducks/types';
 import { getWalletBalances } from 'ducks/balances';
 import { CRYPTO_CURRENCY_TO_KEY } from 'constants/currency';
+import { getWalletDetails } from 'ducks/wallet';
+import { isGoerliTestnet } from 'helpers/networkHelper';
 
 interface L2BannerProps {
 	setCurrentPage: Function;
 	walletBalances: any;
+	walletDetails: any;
 }
-const L2Banner: React.FC<L2BannerProps> = ({ setCurrentPage, walletBalances }) => {
+const L2Banner: React.FC<L2BannerProps> = ({ setCurrentPage, walletBalances, walletDetails }) => {
 	// Only show the banner if their SNX balance is 5000 or less
 	const showBanner =
+		isGoerliTestnet(walletDetails.networkId) &&
 		walletBalances &&
 		walletBalances.crypto &&
-		walletBalances.crypto[CRYPTO_CURRENCY_TO_KEY.SNX] > 0 &&
-		walletBalances.crypto[CRYPTO_CURRENCY_TO_KEY.SNX] <= 5000;
+		walletBalances.crypto[CRYPTO_CURRENCY_TO_KEY.SNX] > 0;
+
 	return showBanner ? (
 		<ContainerBanner onClick={() => setCurrentPage(PAGES_BY_KEY.L2ONBOARDING)}>
 			<StyledPMedium>Save on gas fees by staking on l2. Click here to move to l2!</StyledPMedium>
@@ -49,6 +53,7 @@ const StyledPMedium = styled.p`
 
 const mapStateToProps = (state: RootState) => ({
 	walletBalances: getWalletBalances(state),
+	walletDetails: getWalletDetails(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/Banner/L2Banner.tsx
+++ b/src/components/Banner/L2Banner.tsx
@@ -18,6 +18,7 @@ const L2Banner: React.FC<L2BannerProps> = ({ setCurrentPage, walletBalances }) =
 	const showBanner =
 		walletBalances &&
 		walletBalances.crypto &&
+		walletBalances.crypto[CRYPTO_CURRENCY_TO_KEY.SNX] > 0 &&
 		walletBalances.crypto[CRYPTO_CURRENCY_TO_KEY.SNX] <= 5000;
 	return showBanner ? (
 		<ContainerBanner onClick={() => setCurrentPage(PAGES_BY_KEY.L2ONBOARDING)}>

--- a/src/components/Banner/L2Banner.tsx
+++ b/src/components/Banner/L2Banner.tsx
@@ -14,7 +14,7 @@ interface L2BannerProps {
 	walletBalances: any;
 }
 const L2Banner: React.FC<L2BannerProps> = ({ setCurrentPage, walletBalances }) => {
-	// Only show the banner if their SNX balance is 5000 or less. 
+	// Only show the banner if their SNX balance is 5000 or less
 	const showBanner =
 		walletBalances &&
 		walletBalances.crypto &&

--- a/src/components/Banner/L2Banner.tsx
+++ b/src/components/Banner/L2Banner.tsx
@@ -5,17 +5,26 @@ import { setCurrentPage } from '../../ducks/ui';
 import { PAGES_BY_KEY } from '../../constants/ui';
 import { connect } from 'react-redux';
 import { fontFamilies } from 'styles/themes';
+import { RootState } from 'ducks/types';
+import { getWalletBalances } from 'ducks/balances';
+import { CRYPTO_CURRENCY_TO_KEY } from 'constants/currency';
 
 interface L2BannerProps {
 	setCurrentPage: Function;
+	walletBalances: any;
 }
-const L2Banner: React.FC<L2BannerProps> = ({ setCurrentPage }) => {
-	return (
+const L2Banner: React.FC<L2BannerProps> = ({ setCurrentPage, walletBalances }) => {
+	// Only show the banner if their SNX balance is 5000 or less. 
+	const showBanner =
+		walletBalances &&
+		walletBalances.crypto &&
+		walletBalances.crypto[CRYPTO_CURRENCY_TO_KEY.SNX] <= 5000;
+	return showBanner ? (
 		<ContainerBanner onClick={() => setCurrentPage(PAGES_BY_KEY.L2ONBOARDING)}>
 			<StyledPMedium>Save on gas fees by staking on l2. Click here to move to l2!</StyledPMedium>
 			<DiagonalArrow />
 		</ContainerBanner>
-	);
+	) : null;
 };
 
 const ContainerBanner = styled.div`
@@ -37,8 +46,12 @@ const StyledPMedium = styled.p`
 	margin-right: 4px;
 `;
 
+const mapStateToProps = (state: RootState) => ({
+	walletBalances: getWalletBalances(state),
+});
+
 const mapDispatchToProps = {
 	setCurrentPage,
 };
 
-export default connect(null, mapDispatchToProps)(L2Banner);
+export default connect(mapStateToProps, mapDispatchToProps)(L2Banner);

--- a/src/components/Typography/DynamicComponent.js
+++ b/src/components/Typography/DynamicComponent.js
@@ -15,8 +15,8 @@ import {
 } from 'styled-system';
 
 export default styled.div`
-  ${space}
-  ${fontSize}
+	${space}
+	${fontSize}
   ${fontStyle}
   ${color}
   ${size}

--- a/src/helpers/networkHelper.js
+++ b/src/helpers/networkHelper.js
@@ -136,3 +136,4 @@ export const addBufferToGasLimit = gasLimit =>
 	Math.round(Number(gasLimit) * (1 + GAS_LIMIT_BUFFER_PERCENTAGE));
 
 export const isMainNet = networkId => networkId === Number(SUPPORTED_NETWORKS_MAP.MAINNET);
+export const isGoerliTestnet = networkId => networkId === Number(SUPPORTED_NETWORKS_MAP.GOERLI);


### PR DESCRIPTION
Only show the L2 Migration banner if the user has less than 5000 SNX in their wallet.