### PR TITLE
feat: add etherscan link to all events

### DIFF
--- a/src/helpers/notifyHelper.js
+++ b/src/helpers/notifyHelper.js
@@ -2,13 +2,22 @@ import { getEtherscanTxLink } from 'helpers/explorers';
 
 export function notifyHandler(notify, hash, networkId, callback, message) {
 	let { emitter } = notify.hash(hash);
-	emitter.on('txConfirmed', result => {
+
+	const link = getEtherscanTxLink(networkId, hash);
+
+	emitter.on('all', () => {
+		return {
+			link,
+		};
+	});
+
+	emitter.on('txConfirmed', () => {
 		setTimeout(() => {
 			callback();
 		}, 15000);
 		return {
 			message: message ? message : undefined,
-			link: getEtherscanTxLink(networkId, result.hash),
+			link,
 			autoDismiss: false,
 		};
 	});

--- a/src/helpers/notifyHelper.js
+++ b/src/helpers/notifyHelper.js
@@ -2,7 +2,6 @@ import { getEtherscanTxLink } from 'helpers/explorers';
 
 export function notifyHandler(notify, hash, networkId, callback, message) {
 	let { emitter } = notify.hash(hash);
-
 	const link = getEtherscanTxLink(networkId, hash);
 
 	emitter.on('all', () => {

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Dashboard from 'screens/Dashboard';
 import MintrPanel from 'screens/MintrPanel';
 import BannerL2 from 'components/Banner/BannerL2';
-import BannerGoerliAirdrop from 'components/Banner/BannerGoerliAirdrop'
+import BannerGoerliAirdrop from 'components/Banner/BannerGoerliAirdrop';
 import LiquidationBanner from 'components/BannerLiquidation';
 
 type MainProps = {


### PR DESCRIPTION
Jordan requested that we link out in even when the tx is pending, etc.
I've used the "all" events to add the link to all (hash) events.

Also, I've made a little refactor to use the `link` reusable between the two functions.