### PR TITLE
Fix npm script errors on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1355,6 +1355,16 @@
 						"klaw": "^1.0.0",
 						"path-is-absolute": "^1.0.0",
 						"rimraf": "^2.2.8"
+					},
+					"dependencies": {
+						"rimraf": {
+							"version": "2.7.1",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						}
 					}
 				},
 				"get-caller-file": {
@@ -2002,6 +2012,16 @@
 						"klaw": "^1.0.0",
 						"path-is-absolute": "^1.0.0",
 						"rimraf": "^2.2.8"
+					},
+					"dependencies": {
+						"rimraf": {
+							"version": "2.7.1",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						}
 					}
 				},
 				"js-sha3": {
@@ -2183,6 +2203,16 @@
 						"klaw": "^1.0.0",
 						"path-is-absolute": "^1.0.0",
 						"rimraf": "^2.2.8"
+					},
+					"dependencies": {
+						"rimraf": {
+							"version": "2.7.1",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						}
 					}
 				},
 				"jsonfile": {
@@ -2856,6 +2886,14 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
 					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				}
 			}
 		},
@@ -3483,6 +3521,16 @@
 								"klaw": "^1.0.0",
 								"path-is-absolute": "^1.0.0",
 								"rimraf": "^2.2.8"
+							},
+							"dependencies": {
+								"rimraf": {
+									"version": "2.7.1",
+									"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+									"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+									"requires": {
+										"glob": "^7.1.3"
+									}
+								}
 							}
 						},
 						"jsonfile": {
@@ -8462,6 +8510,16 @@
 				"mkdirp": "^0.5.1",
 				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.0"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"copy-descriptor": {
@@ -8553,6 +8611,58 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
+			}
+		},
+		"cross-env": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+			"integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.1"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		},
 		"cross-fetch": {
@@ -9349,6 +9459,14 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				}
 			}
 		},
@@ -12111,6 +12229,16 @@
 				"flatted": "^2.0.0",
 				"rimraf": "2.6.3",
 				"write": "1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"flatted": {
@@ -21828,6 +21956,14 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				}
 			}
 		},
@@ -24293,6 +24429,16 @@
 				"mkdirp": "^0.5.1",
 				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"ms": {
@@ -25225,6 +25371,14 @@
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^4.0.0",
 						"universalify": "^0.1.0"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"semver": {
@@ -28086,9 +28240,10 @@
 			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
 		},
 		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -32382,6 +32537,16 @@
 						"ssri": "^6.0.1",
 						"unique-filename": "^1.1.1",
 						"y18n": "^4.0.0"
+					},
+					"dependencies": {
+						"rimraf": {
+							"version": "2.7.1",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						}
 					}
 				},
 				"eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -58,10 +58,12 @@
 		"@types/react-table": "^7.0.16",
 		"@types/styled-components": "^5.0.1",
 		"@typescript-eslint/parser": "^3.3.0",
+		"cross-env": "^7.0.2",
 		"eslint-config-prettier": "^6.10.1",
 		"eslint-import-resolver-typescript": "^2.0.0",
 		"eslint-plugin-prettier": "^3.1.3",
 		"prettier": "^2.0.5",
+		"rimraf": "^3.0.2",
 		"storybook-addon-styled-component-theme": "^1.3.0",
 		"stylelint": "^13.3.2",
 		"stylelint-config-recommended": "^3.0.0",
@@ -69,15 +71,15 @@
 		"stylelint-processor-styled-components": "^1.10.0"
 	},
 	"scripts": {
-		"clean-install": "rm ./package-lock.json && rm -rf node_modules/* && npm i",
-		"start": "REACT_APP_VERSION=$npm_package_version react-scripts --max-old-space-size=4096 start",
-		"build": "REACT_APP_VERSION=$npm_package_version react-scripts --max-old-space-size=4096 build",
+		"clean-install": "rimraf ./package-lock.json && rimraf node_modules/* && npm i",
+		"start": "cross-env REACT_APP_VERSION=$npm_package_version react-scripts --max-old-space-size=4096 start",
+		"build": "cross-env REACT_APP_VERSION=$npm_package_version react-scripts --max-old-space-size=4096 build",
 		"test": "react-scripts test",
 		"eject": "react-scripts eject",
 		"tsc": "tsc --noemit",
-		"lint:fix": "eslint --fix './src/**/*.{js,ts,tsx}'",
-		"lint:css": "stylelint './src/**/*.{js,ts,tsx}'",
-		"lint": "eslint './src/**/*.{js,ts,tsx}' && tsc"
+		"lint:fix": "eslint --fix \"./src/**/*.{js,ts,tsx}\"",
+		"lint:css": "stylelint \"./src/**/*.{js,ts,tsx}\"",
+		"lint": "eslint \"./src/**/*.{js,ts,tsx}\" && tsc"
 	},
 	"eslintConfig": {
 		"extends": "react-app"


### PR DESCRIPTION
Similar to [the PR](https://github.com/Synthetixio/synthetix-js/pull/61) on _synthetix-js_, this PR fixes npm scripts on Windows.

A side-effect of this fix is that you can no longer run `npm run clean-install` on a freshly cloned repository, unless you have `rimraf` globally installed.