### PR TITLE
ci: add dockerhub auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,16 @@ workflows:
 
   build-lint-test:
     jobs:
-      - build
+      - build:
+          context:
+            - Docker Auth
       - lint:
           requires:
             - build
+          context:
+            - Docker Auth
       # - test:
       #     requires:
       #       - build
+      #     context:
+      #       - Docker Auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,9 @@ env_defaults: &env_defaults
   working_directory: ~
   docker:
     - image: circleci/node:10.16
-
+      auth:
+        username: $DOCKERHUB_USERNAME
+        password: $DOCKERHUB_TOKEN
 version: 2.1
 jobs:
   build:


### PR DESCRIPTION
Added docker authentication while pulling images.

https://support.circleci.com/hc/en-us/articles/360050623311-Docker-Hub-rate-limiting-FAQ

Signed-off-by: Jakub Mucha jakub.mucha@icloud.com